### PR TITLE
Fix provider name typo in gh-pages

### DIFF
--- a/gh-pages/src/containers/_app/_app.tsx
+++ b/gh-pages/src/containers/_app/_app.tsx
@@ -1,6 +1,6 @@
 import { Navbar } from '@app/containers/_app'
 import styles from '@app/containers/_app/app.module.css'
-import { TerraofmrPlanProvider } from '@app/context/terraform-plan'
+import { TerraformPlanProvider } from '@app/context/terraform-plan'
 import { ReactGa } from '@app/utils/google-analytics'
 import Head from 'next/head'
 import { Router } from 'next/router'
@@ -30,13 +30,13 @@ export const C = ({ Component, pageProps }: any) => {
         />
       </Head>
 
-      <TerraofmrPlanProvider>
+      <TerraformPlanProvider>
         <Navbar.C />
 
         <div className={styles.container}>
           <Component {...pageProps} />
         </div>
-      </TerraofmrPlanProvider>
+      </TerraformPlanProvider>
     </>
   )
 }

--- a/gh-pages/src/context/terraform-plan.tsx
+++ b/gh-pages/src/context/terraform-plan.tsx
@@ -32,7 +32,7 @@ const reducer = (state: State, action: Action<Entities.TerraformPlan>) => {
   }
 }
 
-export const TerraofmrPlanProvider = ({ children }: any) => {
+export const TerraformPlanProvider = ({ children }: any) => {
   const [state, Dispatch] = useReducer(reducer, {})
 
   return (


### PR DESCRIPTION
## Summary
- fix typo `TerraofmrPlanProvider` -> `TerraformPlanProvider`
- use updated provider in `_app`

## Testing
- `npx --yes tsc -p gh-pages/tsconfig.json`

------
https://chatgpt.com/codex/tasks/task_e_688a9994ff608322b19cb98701dece19