### PR TITLE
Improve CLI plan validation and opening

### DIFF
--- a/cli/src/open.ts
+++ b/cli/src/open.ts
@@ -1,0 +1,25 @@
+import { spawn } from 'child_process'
+
+export default function open(target: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    let command = ''
+    let args: string[] = []
+
+    if (process.platform === 'darwin') {
+      command = 'open'
+      args = [target]
+    } else if (process.platform === 'win32') {
+      command = 'cmd'
+      args = ['/c', 'start', '', target]
+    } else {
+      command = 'xdg-open'
+      args = [target]
+    }
+
+    const child = spawn(command, args, { stdio: 'ignore', detached: true })
+    child.on('error', reject)
+    child.unref()
+    resolve()
+  })
+}
+


### PR DESCRIPTION
## Summary
- ensure Terraform plan is readable before continuing
- launch the report using a cross-platform `open` helper

## Testing
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_688a99b9262c8322bac95e517d578a18