### PR TITLE
Fix plan view sizing

### DIFF
--- a/cli/template/src/components/focused-view/focused-view.module.css
+++ b/cli/template/src/components/focused-view/focused-view.module.css
@@ -1,5 +1,6 @@
 .container {
-  height: 40rem;
+  height: 40vh;
+  max-height: 40rem;
   width: 100%;
 
   padding: 1.5rem;

--- a/cli/template/src/components/plan-graph/plan-graph.module.css
+++ b/cli/template/src/components/plan-graph/plan-graph.module.css
@@ -2,7 +2,8 @@
   display: flex;
   justify-content: center;
 
-  height: 55rem;
+  height: 55vh;
+  max-height: 55rem;
 
   margin-bottom: 2rem;
 

--- a/cli/template/src/components/plan-graph/plan-graph.tsx
+++ b/cli/template/src/components/plan-graph/plan-graph.tsx
@@ -35,7 +35,7 @@ export const C = (props: Props) => {
       // @ts-ignore
       container: ref.current,
       width: ref?.current?.clientWidth || 0,
-      height: 550, // TODO: customize
+      height: ref?.current?.clientHeight || 550,
       linkCenter: true,
       modes: {
         default: [

--- a/gh-pages/src/components/focused-view/focused-view.module.css
+++ b/gh-pages/src/components/focused-view/focused-view.module.css
@@ -1,5 +1,6 @@
 .container {
-  height: 40rem;
+  height: 40vh;
+  max-height: 40rem;
   width: 100%;
 
   padding: 1.5rem;

--- a/gh-pages/src/components/plan-graph/plan-graph.module.css
+++ b/gh-pages/src/components/plan-graph/plan-graph.module.css
@@ -2,7 +2,8 @@
   display: flex;
   justify-content: center;
 
-  height: 55rem;
+  height: 55vh;
+  max-height: 55rem;
 
   margin-bottom: 2rem;
 

--- a/gh-pages/src/components/plan-graph/plan-graph.tsx
+++ b/gh-pages/src/components/plan-graph/plan-graph.tsx
@@ -35,7 +35,7 @@ export const C = (props: Props) => {
       // @ts-ignore
       container: ref.current,
       width: ref?.current?.clientWidth || 0,
-      height: 550, // TODO: customize
+      height: ref?.current?.clientHeight || 550,
       linkCenter: true,
       modes: {
         default: [


### PR DESCRIPTION
## Summary
- use viewport units for plan graph and focused view heights
- size the G6 graph based on container height

## Testing
- `yarn --cwd gh-pages build` *(fails: digital envelope routines::unsupported)*
- `yarn --cwd cli/template build` *(fails: package doesn't seem to be present in lockfile)*

------
https://chatgpt.com/codex/tasks/task_e_688aa5904ae88322835dd4432880ddb0