### PR TITLE
Update CLI deps and add basic tests

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -11,18 +11,19 @@
     "build:cli": "rm -rf dist && yarn tsc",
     "dev:cli": "ts-node src/index",
     "build:template": "cd template && rm -rf .next && rm -rf dist && yarn next build && yarn next export -o dist",
-    "dev:template": "cd template && yarn next dev"
+    "dev:template": "cd template && yarn next dev",
+    "test": "node --test"
   },
   "devDependencies": {
-    "@types/fs-extra": "^9.0.1",
-    "@types/node": "^14.0.26",
+    "@types/fs-extra": "^11.0.1",
+    "@types/node": "^20.0.0",
     "@types/react": "^16.9.43",
     "ts-node": "^8.10.2",
     "typescript": "^3.9.7"
   },
   "dependencies": {
-    "commander": "^6.0.0",
-    "fs-extra": "^9.0.1"
+    "commander": "^11.0.0",
+    "fs-extra": "^11.1.1"
   },
   "repository": {
     "type": "git",

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert';
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFile } from 'node:child_process';
+import { promisify } from 'node:util';
+
+const execFileP = promisify(execFile);
+
+const cliDir = process.cwd();
+
+function runCli(planPath, outDir) {
+  return execFileP('node', ['node_modules/ts-node/dist/bin.js', 'src/index.ts', '--plan', planPath, '--out', outDir], { cwd: cliDir });
+}
+
+test('cli generates report', async () => {
+  const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tfvisual-'));
+  const planPath = path.join(tmpDir, 'plan.json');
+  fs.writeFileSync(planPath, '{}');
+  await runCli(planPath, tmpDir);
+  const reportDir = path.join(tmpDir, 'terraform-visual-report');
+  assert.ok(fs.existsSync(path.join(reportDir, 'index.html')));
+  assert.ok(fs.existsSync(path.join(reportDir, 'plan.js')));
+});


### PR DESCRIPTION
## Summary
- bump commander and fs-extra dependencies
- bump TypeScript typings
- add test script for CLI
- basic test to verify the CLI generates a report

## Testing
- `node --test test/cli.test.js`

------
https://chatgpt.com/codex/tasks/task_e_688b9984d64c8322b6c1fb26e4193780