### PR TITLE
Update fs-extra dependency and fix CLI tests

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -15,7 +15,7 @@
     "test": "node --test"
   },
   "devDependencies": {
-    "@types/fs-extra": "^11.0.1",
+    "@types/fs-extra": "^11.0.4",
     "@types/node": "^20.0.0",
     "@types/react": "^16.9.43",
     "ts-node": "^8.10.2",
@@ -23,7 +23,7 @@
   },
   "dependencies": {
     "commander": "^11.0.0",
-    "fs-extra": "^11.1.1"
+    "fs-extra": "^11.3.0"
   },
   "repository": {
     "type": "git",

--- a/cli/test/cli.test.js
+++ b/cli/test/cli.test.js
@@ -18,7 +18,14 @@ test('cli generates report', async () => {
   const tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), 'tfvisual-'));
   const planPath = path.join(tmpDir, 'plan.json');
   fs.writeFileSync(planPath, '{}');
+
+  const templateDist = path.join(cliDir, 'template', 'dist');
+  fs.mkdirSync(templateDist, { recursive: true });
+  fs.writeFileSync(path.join(templateDist, 'index.html'), '<html></html>');
+
   await runCli(planPath, tmpDir);
+
+  fs.rmSync(templateDist, { recursive: true, force: true });
   const reportDir = path.join(tmpDir, 'terraform-visual-report');
   assert.ok(fs.existsSync(path.join(reportDir, 'index.html')));
   assert.ok(fs.existsSync(path.join(reportDir, 'plan.js')));


### PR DESCRIPTION
## Summary
- bump `fs-extra` to 11.3.0 and `@types/fs-extra` to 11.0.4
- make the CLI test create a temporary `template/dist` so the test can run without building Next.js

## Testing
- `yarn install` && `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688ba7307710832293c54355ed5f9e93