### PR TITLE
Add CI test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,21 @@
+name: CI
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-node@v3
+        with:
+          node-version: '20'
+          cache: 'yarn'
+          cache-dependency-path: cli/yarn.lock
+      - name: Install dependencies
+        run: yarn --cwd cli install --frozen-lockfile
+      - name: Run tests
+        run: yarn --cwd cli test

--- a/README.md
+++ b/README.md
@@ -59,3 +59,15 @@ The Docker image builds on top of the official Terraform image and includes Terr
 Simply replace the Terraform image in your pipeline with this one to take advantage of both tools.
 
 For more details, please refer to [Docker: Terraform-Visual](https://hub.docker.com/r/hieven/terraform-visual-cli)
+
+## Running Tests
+
+To verify changes locally, install dependencies and run:
+
+```sh
+npm install --prefix cli
+npm test
+```
+
+This runs the CLI unit tests using Node\x27s built-in test runner.
+

--- a/package.json
+++ b/package.json
@@ -1,0 +1,7 @@
+{
+  "name": "terraform-visual-root",
+  "private": true,
+  "scripts": {
+    "test": "npm --prefix cli test"
+  }
+}


### PR DESCRIPTION
## Summary
- add a minimal test workflow
- document how to run tests locally
- provide root `package.json` to simplify running tests

## Testing
- `npm install --prefix cli`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688bc964303083228d3e5aaeeb5b8535